### PR TITLE
Secure DOIs

### DIFF
--- a/app/assets/javascripts/datasets.js
+++ b/app/assets/javascripts/datasets.js
@@ -134,7 +134,7 @@ ready = function () {
     });
 
     $('#dataset_identifier').change(function () {
-        $('#doi-preview').html("http://dx.doi.org/" + $(this).val());
+        $('#doi-preview').html("https://doi.org/" + $(this).val());
     });
 
     $('#show-all-button').click(function () {

--- a/app/controllers/concerns/datasets/publication_state_methods.rb
+++ b/app/controllers/concerns/datasets/publication_state_methods.rb
@@ -9,13 +9,13 @@ module Datasets
 
       case new_state
         when Databank::PublicationState::RELEASED
-          return %Q[Dataset was successfully published and the DataCite DOI is #{dataset.identifier}.<br/>The persistent link to this dataset is now <a href = "http://dx.doi.org/#{dataset.identifier}">http://dx.doi.org/#{dataset.identifier}</a>.<br/>There may be a delay before the persistent link will be in effect.  If this link does not redirect to the dataset immediately, try again in an hour.]
+          return %Q[Dataset was successfully published and the DataCite DOI is #{dataset.identifier}.<br/>The persistent link to this dataset is now <a href = "https://doi.org/#{dataset.identifier}">https://doi.org/#{dataset.identifier}</a>.<br/>There may be a delay before the persistent link will be in effect.  If this link does not redirect to the dataset immediately, try again in an hour.]
 
         when Databank::PublicationState::Embargo::METADATA
-          return %Q[DataCite DOI #{dataset.identifier} successfully reserved.<br/>The persistent link to this dataset will be <a href = "http://dx.doi.org/#{dataset.identifier}">http://dx.doi.org/#{dataset.identifier}</a> starting #{dataset.release_date}.]
+          return %Q[DataCite DOI #{dataset.identifier} successfully reserved.<br/>The persistent link to this dataset will be <a href = "https://doi.org/#{dataset.identifier}">https://doi.org/#{dataset.identifier}</a> starting #{dataset.release_date}.]
 
         when Databank::PublicationState::Embargo::FILE
-          return %Q[Dataset record was successfully published and the DataCite DOI is #{dataset.identifier}.<br/>Although the record for your dataset will be publicly visible, your data files will not be made available until #{dataset.release_date.iso8601}.<br/>The persistent link to this dataset is now <a href = "http://dx.doi.org/#{dataset.identifier}">http://dx.doi.org/#{dataset.identifier}</a>.<br/>There may be a delay before the persistent link will be in effect.  If this link does not redirect to the dataset immediately, try again in an hour.]
+          return %Q[Dataset record was successfully published and the DataCite DOI is #{dataset.identifier}.<br/>Although the record for your dataset will be publicly visible, your data files will not be made available until #{dataset.release_date.iso8601}.<br/>The persistent link to this dataset is now <a href = "https://doi.org/#{dataset.identifier}">https://doi.org/#{dataset.identifier}</a>.<br/>There may be a delay before the persistent link will be in effect.  If this link does not redirect to the dataset immediately, try again in an hour.]
       end
 
     end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -737,7 +737,7 @@ class DatasetsController < ApplicationController
     if @dataset.identifier
       urlNode = doc.create_element('url')
       urlNode.parent = relatedurlsNode
-      urlNode.content = "http://dx.doi.org/#{@dataset.identifier}"
+      urlNode.content = "https://doi.org/#{@dataset.identifier}"
     end
 
     electronicNode = doc.create_element('electronic-resource-num')
@@ -764,7 +764,7 @@ class DatasetsController < ApplicationController
 
     t.write(%Q[Provider: Illinois Data Bank\nContent: text/plain; charset=%Q[us-ascii]\nTY  - DATA\nT1  - #{@dataset.title}\n])
 
-    t.write(%Q[DO  - #{@dataset.identifier}\nPY  - #{@dataset.publication_year}\nUR  - http://dx.doi.org/#{@dataset.identifier}\nPB  - #{@dataset.publisher}\nER  - ])
+    t.write(%Q[DO  - #{@dataset.identifier}\nPY  - #{@dataset.publication_year}\nUR  - https://doi.org/#{@dataset.identifier}\nPB  - #{@dataset.publisher}\nER  - ])
 
     if !@dataset.identifier
       @dataset.identifer = @dataset.key
@@ -800,7 +800,7 @@ class DatasetsController < ApplicationController
     t = Tempfile.new("#{@dataset.key}_endNote")
     citekey = SecureRandom.uuid
 
-    t.write("@data{#{citekey},\ndoi = {#{@dataset.identifier}},\nurl = {http://dx.doi.org/#{@dataset.identifier}},\nauthor = {#{@dataset.creator_list}},\npublisher = {#{@dataset.publisher}},\ntitle = {#{@dataset.title} ﻿},\nyear = {#{@dataset.publication_year}}
+    t.write("@data{#{citekey},\ndoi = {#{@dataset.identifier}},\nurl = {https://doi.org/#{@dataset.identifier}},\nauthor = {#{@dataset.creator_list}},\npublisher = {#{@dataset.publisher}},\ntitle = {#{@dataset.title} ﻿},\nyear = {#{@dataset.publication_year}}
 }")
 
     send_file t.path, :type => 'application/application/x-bibtex',

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -156,7 +156,7 @@ class Dataset < ActiveRecord::Base
 
           if funder.identifier && funder.identifier != ''
             funderIdentifierNode = doc.create_element('nameIdentifier')
-            funderIdentifierNode["schemeURI"] = "http://dx.doi.org/"
+            funderIdentifierNode["schemeURI"] = "https://doi.org/"
             funderIdentifierNode["nameIdentifierScheme"] = "DOI"
             funderIdentifierNode.content = "#{funder.identifier}"
             funderIdentifierNode.parent = funderNode
@@ -636,7 +636,7 @@ class Dataset < ActiveRecord::Base
 
     end
 
-    citation_id = (identifier && !identifier.empty?) ? "http://dx.doi.org/#{identifier}" : ""
+    citation_id = (identifier && !identifier.empty?) ? "https://doi.org/#{identifier}" : ""
 
     return "#{creator_list} (#{publication_year}): #{citationTitle}. #{publisher}. #{citation_id}"
   end

--- a/app/views/datasets/_form.html.haml
+++ b/app/views/datasets/_form.html.haml
@@ -21,7 +21,7 @@
             = @dataset.title && @dataset.title != "" ? "#{@dataset.title}." : "[The Title]."
           University of Illinois at Urbana-Champaign.
           %span( id="doi-preview" )
-            = @dataset.identifier && @dataset.identifier != "" ? "http://dx.doi.org/#{@dataset.identifier}" : ""
+            = @dataset.identifier && @dataset.identifier != "" ? "https://doi.org/#{@dataset.identifier}" : ""
         .panel-collapse.collapse.in(id="descriptionPanel" role="tabpanel" aria-labelledby="descriptionHeading" )
           .panel-body
             - if @dataset.errors.any?

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -90,11 +90,11 @@
 
         <% if @dataset.complete? %>
           <div class="row bg-muted">
-          <span id="citation-standards" class="col-md-9 text-muted small"><button class='my_clip_button btn btn-sm btn-default' data-clipboard-target='fe_text' data-clipboard-text="http://dx.doi.org/<%= @dataset.identifier %>" id='d_clip_button' title='Click me to copy to clipboard.'>
+          <span id="citation-standards" class="col-md-9 text-muted small"><button class='my_clip_button btn btn-sm btn-default' data-clipboard-target='fe_text' data-clipboard-text="https://doi.org/<%= @dataset.identifier %>" id='d_clip_button' title='Click me to copy to clipboard.'>
             <span class="glyphicon glyphicon-copy"></span>
             <b>Copy persistent link to clipboard...</b>
-          </button> Persistent link for this item: <a href="http://dx.doi.org/<%= @dataset.identifier %>">http://dx.doi.org/<%= @dataset.identifier %></a></span>
-            <input type="hidden" value="http://dx.doi.org/<%= @dataset.identifier %>" name="fe_text" id="fe_text">
+          </button> Persistent link for this item: <a href="https://doi.org/<%= @dataset.identifier %>">https://doi.org/<%= @dataset.identifier %></a></span>
+            <input type="hidden" value="https://doi.org/<%= @dataset.identifier %>" name="fe_text" id="fe_text">
           </div>
         <% end %>
       </div>

--- a/app/views/help/_license.html.haml
+++ b/app/views/help/_license.html.haml
@@ -43,7 +43,7 @@
         %li
           %p
             Carroll, Michael W. 2015. 'Sharing Research Data And Intellectual Property Law: A Primer'. PLOS Biology 13 (8): e1002235.
-            %a(href="http://dx.doi.org/10.1371/journal.pbio.1002235")doi:10.1371/journal.pbio.1002235.
+            %a(href="https://doi.org/10.1371/journal.pbio.1002235")doi:10.1371/journal.pbio.1002235.
       %hr
       %p
         %sup 1

--- a/lib/sample_data/bytestreams/README-McNeill-Robinson.txt
+++ b/lib/sample_data/bytestreams/README-McNeill-Robinson.txt
@@ -1,4 +1,4 @@
-README for Dataset:  Honey bee brain images processed to reveal c-jun mRNA (http://dx.doi.org/10.13012/J8Z60KZG)
+README for Dataset:  Honey bee brain images processed to reveal c-jun mRNA (https://doi.org/10.13012/J8Z60KZG)
 
 ARTICLE DESCRITPION
 


### PR DESCRIPTION
The DOI foundation has [stopped listing the `dx` resolver as "preferred", and started to support HTTPS](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). I hope I correctly understood your code to generate/display DOI links, not parse them.